### PR TITLE
Add admin dashboard route and management UI

### DIFF
--- a/src/app/admin/admin-dashboard.component.html
+++ b/src/app/admin/admin-dashboard.component.html
@@ -1,0 +1,265 @@
+@if (isAdmin()) {
+  <div class="admin-dashboard">
+    <header class="admin-dashboard__hero">
+      <div class="admin-dashboard__intro">
+        <h1>Store Control Center</h1>
+        <p>
+          Shape every part of your storefront from a single, focused workspace. Manage branding,
+          inventory, and contact touchpoints with live feedback.
+        </p>
+        <div class="admin-dashboard__actions">
+          <button type="button" class="ghost" (click)="startWizard()">Launch setup wizard</button>
+          <button type="button" class="ghost" (click)="navigateToStore()">View live site</button>
+        </div>
+      </div>
+      <section class="admin-dashboard__metrics">
+        <article class="metric">
+          <span class="metric__label">Products</span>
+          <span class="metric__value">{{ totalProducts() }}</span>
+          <small class="metric__hint">Currently visible on the storefront</small>
+        </article>
+        <article class="metric">
+          <span class="metric__label">Categories</span>
+          <span class="metric__value">{{ totalCategories() }}</span>
+          <small class="metric__hint">Grouped by primary product category</small>
+        </article>
+        <article class="metric">
+          <span class="metric__label">Status</span>
+          <span class="metric__value metric__value--status">
+            @if (hasUnsavedChanges()) {
+              Draft
+            } @else {
+              Published
+            }
+          </span>
+          <small class="metric__hint">
+            @if (lastSavedAt()) {
+              Last saved {{ lastSavedAt() | date: 'shortTime' }}
+            } @else {
+              Save to push live updates
+            }
+          </small>
+        </article>
+      </section>
+    </header>
+
+    <main class="admin-dashboard__content">
+      @if (!hasSite()) {
+        <div class="admin-dashboard__empty">
+          <h2>No storefront configured yet</h2>
+          <p>
+            You can start fresh by completing the form below or launch the guided wizard to generate
+            a polished store in minutes.
+          </p>
+        </div>
+      }
+
+      <form class="dashboard-form" [formGroup]="dashboardForm" (ngSubmit)="saveChanges()">
+        <section class="form-section" formGroupName="brand">
+          <div class="section-header">
+            <h2>Brand foundation</h2>
+            <p>Control how your shop introduces itself to visitors.</p>
+          </div>
+          <div class="field-grid">
+            <label class="field">
+              <span>Store name</span>
+              <input type="text" formControlName="storeName" placeholder="Acme Collective" />
+            </label>
+            <label class="field">
+              <span>Tagline</span>
+              <input type="text" formControlName="tagline" placeholder="Everyday staples, elevated" />
+            </label>
+            <label class="field field--full">
+              <span>Logo URL</span>
+              <input type="url" formControlName="logoUrl" placeholder="https://cdn.yoursite.com/logo.svg" />
+            </label>
+          </div>
+        </section>
+
+        <section class="form-section" formGroupName="hero">
+          <div class="section-header">
+            <h2>Hero experience</h2>
+            <p>Refresh imagery, calls-to-action, and brand colors in one place.</p>
+          </div>
+          <div class="field-grid">
+            <label class="field field--full">
+              <span>Hero image URL</span>
+              <input type="url" formControlName="heroImageUrl" placeholder="https://images.unsplash.com/..." />
+            </label>
+            <label class="field">
+              <span>Primary button label</span>
+              <input type="text" formControlName="heroCtaLabel" placeholder="Shop the collection" />
+            </label>
+            <label class="field">
+              <span>Primary button link</span>
+              <input type="text" formControlName="heroCtaLink" placeholder="#featured-products" />
+            </label>
+            <label class="field">
+              <span>Primary color</span>
+              <input type="color" formControlName="primaryColor" />
+            </label>
+            <label class="field">
+              <span>Accent color</span>
+              <input type="color" formControlName="accentColor" />
+            </label>
+          </div>
+        </section>
+
+        <section class="form-section" formGroupName="about">
+          <div class="section-header">
+            <h2>About spotlight</h2>
+            <p>Tell the story that anchors your brand promise.</p>
+          </div>
+          <div class="field-grid">
+            <label class="field">
+              <span>Headline</span>
+              <input type="text" formControlName="title" placeholder="Our Story" />
+            </label>
+            <label class="field field--full">
+              <span>Narrative</span>
+              <textarea formControlName="description" rows="4" placeholder="Share what makes your products special"></textarea>
+            </label>
+          </div>
+        </section>
+
+        <section class="form-section" formGroupName="contact">
+          <div class="section-header">
+            <h2>Contact & social</h2>
+            <p>Keep customer communication touchpoints accurate and current.</p>
+          </div>
+          <div class="field-grid">
+            <label class="field">
+              <span>Support email</span>
+              <input type="email" formControlName="contactEmail" placeholder="hello@yoursite.com" />
+            </label>
+            <label class="field">
+              <span>Phone</span>
+              <input type="text" formControlName="contactPhone" placeholder="+1 (555) 000-1234" />
+            </label>
+            <label class="field field--full">
+              <span>Address</span>
+              <input type="text" formControlName="contactAddress" placeholder="123 Market Street, San Francisco" />
+            </label>
+            <label class="field">
+              <span>Instagram</span>
+              <input type="url" formControlName="instagramUrl" placeholder="https://instagram.com/yourbrand" />
+            </label>
+            <label class="field">
+              <span>Facebook</span>
+              <input type="url" formControlName="facebookUrl" placeholder="https://facebook.com/yourbrand" />
+            </label>
+          </div>
+        </section>
+
+        <section class="form-section">
+          <div class="section-header">
+            <div>
+              <h2>Product catalog</h2>
+              <p>Curate the merchandise that powers your storefront experience.</p>
+            </div>
+            <button type="button" class="ghost" (click)="addProduct()">Add product</button>
+          </div>
+
+          <div formArrayName="products" class="products-grid">
+            @for (product of productsArray.controls; track trackByIndex($index); let i = $index) {
+              <article class="product-card" [formGroupName]="i">
+                <header class="product-card__header">
+                  <div>
+                    <h3>Product {{ i + 1 }}</h3>
+                    <p>Update details, imagery, and merchandising highlights.</p>
+                  </div>
+                  <button
+                    type="button"
+                    class="ghost ghost--danger"
+                    (click)="removeProduct(i)"
+                    [disabled]="productsArray.length <= 1"
+                  >
+                    Remove
+                  </button>
+                </header>
+
+                <div class="product-card__body">
+                  <div class="field-grid">
+                    <label class="field">
+                      <span>Name</span>
+                      <input type="text" formControlName="name" placeholder="Everyday Tote" />
+                    </label>
+                    <label class="field">
+                      <span>Highlight badge</span>
+                      <input type="text" formControlName="highlight" placeholder="Limited Release" />
+                    </label>
+                    <label class="field">
+                      <span>Price</span>
+                      <input type="number" formControlName="price" min="0" step="0.01" />
+                    </label>
+                    <label class="field">
+                      <span>Slug</span>
+                      <input type="text" formControlName="slug" placeholder="everyday-tote" />
+                    </label>
+                    <label class="field field--full">
+                      <span>Description</span>
+                      <textarea formControlName="description" rows="3" placeholder="Describe the product features"></textarea>
+                    </label>
+                    <label class="field field--full">
+                      <span>Main image URL</span>
+                      <input type="url" formControlName="imageUrl" placeholder="https://images.unsplash.com/..." />
+                    </label>
+                    <label class="field field--full">
+                      <span>Gallery images</span>
+                      <textarea
+                        formControlName="gallery"
+                        rows="3"
+                        placeholder="Add one URL per line"
+                      ></textarea>
+                    </label>
+                    <label class="field">
+                      <span>Available sizes</span>
+                      <textarea formControlName="sizes" rows="2" placeholder="S\nM\nL"></textarea>
+                    </label>
+                    <label class="field">
+                      <span>Available colors</span>
+                      <textarea formControlName="colors" rows="2" placeholder="Charcoal\nSand"></textarea>
+                    </label>
+                    <label class="field">
+                      <span>Category</span>
+                      <input type="text" formControlName="category" placeholder="Apparel" />
+                    </label>
+                    <label class="field">
+                      <span>Sub category</span>
+                      <input type="text" formControlName="subCategory" placeholder="Outerwear" />
+                    </label>
+                  </div>
+                </div>
+              </article>
+            }
+          </div>
+        </section>
+
+        <footer class="form-footer">
+          <div class="form-footer__status">
+            @if (hasUnsavedChanges()) {
+              <span class="status-pill status-pill--warning">Unsaved changes</span>
+            }
+            @if (saveFeedback() === 'saved') {
+              <span class="status-pill status-pill--success">Changes published</span>
+            }
+          </div>
+          <button type="submit" class="primary" [disabled]="dashboardForm.invalid || !hasUnsavedChanges()">
+            Publish updates
+          </button>
+        </footer>
+      </form>
+    </main>
+  </div>
+} @else {
+  <div class="admin-dashboard__unauthorized">
+    <div class="unauthorized-card">
+      <h1>Admin access required</h1>
+      <p>
+        This workspace is reserved for team members with administrative permissions. Sign in with an
+        authorized account to continue.
+      </p>
+      <a class="primary" routerLink="/auth/login">Go to sign in</a>
+    </div>
+  </div>
+}

--- a/src/app/admin/admin-dashboard.component.scss
+++ b/src/app/admin/admin-dashboard.component.scss
@@ -1,0 +1,376 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #eff6ff 0%, #ffffff 45%, #f8fafc 100%);
+}
+
+.admin-dashboard {
+  padding: 3rem clamp(1rem, 6vw, 4rem) 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  color: #0f172a;
+}
+
+.admin-dashboard__hero {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(56, 189, 248, 0.08));
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 24px;
+  padding: clamp(2rem, 5vw, 3rem);
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(2rem, 4vw, 3rem);
+  box-shadow: 0 25px 60px -30px rgba(15, 23, 42, 0.3);
+}
+
+.admin-dashboard__intro {
+  flex: 1 1 280px;
+  max-width: 520px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.admin-dashboard__intro h1 {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+
+.admin-dashboard__intro p {
+  margin: 0;
+  font-size: 1rem;
+  color: rgba(15, 23, 42, 0.7);
+  max-width: 40ch;
+}
+
+.admin-dashboard__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.admin-dashboard__metrics {
+  flex: 1 1 260px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  align-content: start;
+}
+
+.metric {
+  background: rgba(255, 255, 255, 0.65);
+  backdrop-filter: blur(16px);
+  border-radius: 20px;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.metric__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.metric__value {
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  font-weight: 700;
+  color: #0f172a;
+  line-height: 1;
+}
+
+.metric__value--status {
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+  color: #2563eb;
+}
+
+.metric__hint {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.admin-dashboard__content {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.admin-dashboard__empty {
+  background: #0f172a;
+  color: #f8fafc;
+  border-radius: 20px;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: 0 30px 50px -35px rgba(15, 23, 42, 0.7);
+}
+
+.dashboard-form {
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(14px);
+  border-radius: 24px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 20px 45px -35px rgba(15, 23, 42, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+
+.section-header h2 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.4rem, 3vw, 1.75rem);
+  letter-spacing: -0.01em;
+}
+
+.section-header p {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+  max-width: 46ch;
+}
+
+.field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.field span {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.field input,
+.field textarea {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 0.75rem 1rem;
+  background: rgba(248, 250, 252, 0.9);
+  font: inherit;
+  color: #0f172a;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 100px;
+}
+
+.field input:focus,
+.field textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+  background: #fff;
+}
+
+.field--full {
+  grid-column: 1 / -1;
+}
+
+.products-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.product-card {
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(248, 250, 252, 0.9);
+  box-shadow: 0 16px 35px -30px rgba(15, 23, 42, 0.4);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.product-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.product-card__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.product-card__header p {
+  margin: 0.35rem 0 0;
+  color: rgba(15, 23, 42, 0.6);
+  font-size: 0.9rem;
+}
+
+.product-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.form-footer__status {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  padding: 0.4rem 0.95rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.status-pill--warning {
+  background: rgba(249, 115, 22, 0.12);
+  color: #b45309;
+}
+
+.status-pill--success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+button.primary,
+.primary {
+  background: #2563eb;
+  color: #f8fafc;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.8rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  box-shadow: 0 15px 25px -18px rgba(37, 99, 235, 0.6);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+button.primary:not(:disabled):hover,
+.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px -16px rgba(37, 99, 235, 0.65);
+}
+
+button.ghost {
+  background: rgba(15, 23, 42, 0.06);
+  color: #0f172a;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+button.ghost:hover {
+  background: rgba(15, 23, 42, 0.12);
+  border-color: rgba(15, 23, 42, 0.2);
+}
+
+button.ghost--danger {
+  color: #be123c;
+  border-color: rgba(190, 18, 60, 0.3);
+  background: rgba(190, 18, 60, 0.08);
+}
+
+button.ghost--danger:hover {
+  background: rgba(190, 18, 60, 0.15);
+}
+
+.admin-dashboard__unauthorized {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 3rem 1.5rem;
+  background: linear-gradient(150deg, #0f172a, #1e293b);
+}
+
+.unauthorized-card {
+  max-width: 420px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 2.5rem;
+  color: #f8fafc;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 30px 60px -35px rgba(15, 23, 42, 0.8);
+  display: grid;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.unauthorized-card h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.unauthorized-card p {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.75);
+  line-height: 1.6;
+}
+
+@media (max-width: 780px) {
+  .admin-dashboard__hero {
+    border-radius: 20px;
+  }
+
+  .dashboard-form {
+    border-radius: 18px;
+  }
+
+  .product-card {
+    border-radius: 18px;
+  }
+}

--- a/src/app/admin/admin-dashboard.component.ts
+++ b/src/app/admin/admin-dashboard.component.ts
@@ -1,0 +1,380 @@
+import { CommonModule, DatePipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  signal
+} from '@angular/core';
+import {
+  FormArray,
+  FormControl,
+  FormGroup,
+  NonNullableFormBuilder,
+  ReactiveFormsModule,
+  Validators
+} from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AuthService } from '../auth/auth.service';
+import { GeneratedSite, ProductDetails } from '../models/site.model';
+import { SiteStateService } from '../state/site-state.service';
+
+type ProductFormGroup = FormGroup<{
+  name: FormControl<string>;
+  description: FormControl<string>;
+  price: FormControl<number>;
+  imageUrl: FormControl<string>;
+  highlight: FormControl<string>;
+  slug: FormControl<string>;
+  gallery: FormControl<string>;
+  sizes: FormControl<string>;
+  colors: FormControl<string>;
+  category: FormControl<string>;
+  subCategory: FormControl<string>;
+}>;
+
+type SaveFeedback = 'idle' | 'saved';
+
+@Component({
+  selector: 'app-admin-dashboard',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, RouterLink, DatePipe],
+  templateUrl: './admin-dashboard.component.html',
+  styleUrls: ['./admin-dashboard.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AdminDashboardComponent {
+  private readonly fb = inject(NonNullableFormBuilder);
+  private readonly siteState = inject(SiteStateService);
+  private readonly auth = inject(AuthService);
+  private readonly router = inject(Router);
+
+  private skipNextSync = false;
+  private lastSiteSnapshot: string | null = null;
+  private saveToastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  protected readonly isAdmin = this.auth.isAdmin;
+  protected readonly hasSite = this.siteState.hasSite;
+  protected readonly currentSite = this.siteState.site;
+  protected readonly totalProducts = computed(() => this.currentSite()?.products.length ?? 0);
+  protected readonly totalCategories = computed(() => {
+    const site = this.currentSite();
+    if (!site) {
+      return 0;
+    }
+
+    const categories = new Set<string>();
+    site.products.forEach((product) => {
+      categories.add((product.category || 'Uncategorized').trim().toLowerCase());
+    });
+
+    return categories.size;
+  });
+
+  protected readonly dashboardForm = this.fb.group({
+    brand: this.fb.group({
+      storeName: this.fb.control('', [Validators.required, Validators.maxLength(60)]),
+      tagline: this.fb.control('', [Validators.required, Validators.maxLength(120)]),
+      logoUrl: this.fb.control('', [Validators.required])
+    }),
+    hero: this.fb.group({
+      heroImageUrl: this.fb.control('', [Validators.required]),
+      heroCtaLabel: this.fb.control('Shop now', [Validators.required, Validators.maxLength(40)]),
+      heroCtaLink: this.fb.control('#featured-products', [Validators.required, Validators.maxLength(120)]),
+      primaryColor: this.fb.control('#2563eb', [Validators.required]),
+      accentColor: this.fb.control('#f97316', [Validators.required])
+    }),
+    about: this.fb.group({
+      title: this.fb.control('Our Story', [Validators.required, Validators.maxLength(60)]),
+      description: this.fb.control('', [Validators.required, Validators.minLength(30), Validators.maxLength(360)])
+    }),
+    contact: this.fb.group({
+      contactEmail: this.fb.control('', [Validators.required, Validators.email, Validators.maxLength(120)]),
+      contactPhone: this.fb.control('', [Validators.maxLength(40)]),
+      contactAddress: this.fb.control('', [Validators.maxLength(160)]),
+      instagramUrl: this.fb.control('', [Validators.maxLength(160)]),
+      facebookUrl: this.fb.control('', [Validators.maxLength(160)])
+    }),
+    products: this.fb.array<ProductFormGroup>([])
+  });
+
+  protected readonly productsArray = this.dashboardForm.controls.products;
+  protected readonly hasUnsavedChanges = signal(false);
+  protected readonly saveFeedback = signal<SaveFeedback>('idle');
+  protected readonly lastSavedAt = signal<Date | null>(null);
+
+  constructor() {
+    effect(
+      () => {
+        const site = this.currentSite();
+        const serialized = site ? JSON.stringify(site) : null;
+
+        if (this.skipNextSync) {
+          this.skipNextSync = false;
+          this.lastSiteSnapshot = serialized;
+          return;
+        }
+
+        if (serialized === this.lastSiteSnapshot) {
+          return;
+        }
+
+        this.lastSiteSnapshot = serialized;
+        this.resetForm(site ?? null);
+      },
+      { allowSignalWrites: true }
+    );
+
+    this.dashboardForm.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => {
+      this.hasUnsavedChanges.set(this.dashboardForm.dirty);
+      if (this.saveFeedback() !== 'idle') {
+        this.saveFeedback.set('idle');
+      }
+    });
+  }
+
+  protected trackByIndex(index: number): number {
+    return index;
+  }
+
+  protected addProduct(): void {
+    this.productsArray.push(this.buildProductGroup());
+    this.markDirty();
+  }
+
+  protected removeProduct(index: number): void {
+    if (this.productsArray.length <= 1) {
+      return;
+    }
+
+    this.productsArray.removeAt(index);
+    this.markDirty();
+  }
+
+  protected saveChanges(): void {
+    if (this.dashboardForm.invalid) {
+      this.dashboardForm.markAllAsTouched();
+      return;
+    }
+
+    const raw = this.dashboardForm.getRawValue();
+    const usedSlugs = new Set<string>();
+    const products: ProductDetails[] = raw.products.map((product, index) => {
+      const normalizedSlug = this.generateSlug(product.slug || product.name, index, usedSlugs);
+
+      return {
+        name: product.name,
+        description: product.description,
+        price: product.price,
+        imageUrl: product.imageUrl,
+        highlight: product.highlight,
+        slug: normalizedSlug,
+        gallery: this.parseList(product.gallery),
+        sizes: this.parseList(product.sizes),
+        colors: this.parseList(product.colors),
+        category: product.category || undefined,
+        subCategory: product.subCategory || undefined
+      } satisfies ProductDetails;
+    });
+
+    const site: GeneratedSite = {
+      storeName: raw.brand.storeName,
+      tagline: raw.brand.tagline,
+      logoUrl: raw.brand.logoUrl,
+      heroImageUrl: raw.hero.heroImageUrl,
+      heroCtaLabel: raw.hero.heroCtaLabel,
+      heroCtaLink: raw.hero.heroCtaLink,
+      primaryColor: raw.hero.primaryColor,
+      accentColor: raw.hero.accentColor,
+      about: {
+        title: raw.about.title,
+        description: raw.about.description
+      },
+      contact: {
+        contactEmail: raw.contact.contactEmail,
+        contactPhone: raw.contact.contactPhone,
+        contactAddress: raw.contact.contactAddress,
+        instagramUrl: raw.contact.instagramUrl,
+        facebookUrl: raw.contact.facebookUrl
+      },
+      products
+    } satisfies GeneratedSite;
+
+    this.skipNextSync = true;
+    this.siteState.setSite(site);
+    this.resetForm(site);
+    this.hasUnsavedChanges.set(false);
+    this.saveFeedback.set('saved');
+    this.lastSavedAt.set(new Date());
+
+    if (this.saveToastTimer) {
+      clearTimeout(this.saveToastTimer);
+    }
+
+    this.saveToastTimer = setTimeout(() => {
+      this.saveFeedback.set('idle');
+      this.saveToastTimer = null;
+    }, 2500);
+  }
+
+  protected startWizard(): void {
+    if (this.siteState.openWizard()) {
+      void this.router.navigateByUrl('/');
+    }
+  }
+
+  protected navigateToStore(): void {
+    void this.router.navigateByUrl('/');
+  }
+
+  private markDirty(): void {
+    if (!this.dashboardForm.dirty) {
+      this.dashboardForm.markAsDirty();
+    }
+    this.hasUnsavedChanges.set(true);
+  }
+
+  private resetForm(site: GeneratedSite | null): void {
+    const brandGroup = this.dashboardForm.controls.brand;
+    const heroGroup = this.dashboardForm.controls.hero;
+    const aboutGroup = this.dashboardForm.controls.about;
+    const contactGroup = this.dashboardForm.controls.contact;
+    const productsArray = this.productsArray;
+
+    while (productsArray.length) {
+      productsArray.removeAt(0);
+    }
+
+    if (!site) {
+      brandGroup.reset({ storeName: '', tagline: '', logoUrl: '' }, { emitEvent: false });
+      heroGroup.reset(
+        {
+          heroImageUrl: '',
+          heroCtaLabel: 'Shop now',
+          heroCtaLink: '#featured-products',
+          primaryColor: '#2563eb',
+          accentColor: '#f97316'
+        },
+        { emitEvent: false }
+      );
+      aboutGroup.reset(
+        {
+          title: 'Our Story',
+          description:
+            'Share the heart of your brand, your craft, and what makes your products worth discovering.'
+        },
+        { emitEvent: false }
+      );
+      contactGroup.reset(
+        {
+          contactEmail: '',
+          contactPhone: '',
+          contactAddress: '',
+          instagramUrl: '',
+          facebookUrl: ''
+        },
+        { emitEvent: false }
+      );
+      productsArray.push(this.buildProductGroup());
+    } else {
+      brandGroup.reset(
+        {
+          storeName: site.storeName,
+          tagline: site.tagline,
+          logoUrl: site.logoUrl
+        },
+        { emitEvent: false }
+      );
+      heroGroup.reset(
+        {
+          heroImageUrl: site.heroImageUrl,
+          heroCtaLabel: site.heroCtaLabel,
+          heroCtaLink: site.heroCtaLink,
+          primaryColor: site.primaryColor,
+          accentColor: site.accentColor
+        },
+        { emitEvent: false }
+      );
+      aboutGroup.reset(
+        {
+          title: site.about.title,
+          description: site.about.description
+        },
+        { emitEvent: false }
+      );
+      contactGroup.reset(
+        {
+          contactEmail: site.contact.contactEmail,
+          contactPhone: site.contact.contactPhone ?? '',
+          contactAddress: site.contact.contactAddress ?? '',
+          instagramUrl: site.contact.instagramUrl ?? '',
+          facebookUrl: site.contact.facebookUrl ?? ''
+        },
+        { emitEvent: false }
+      );
+
+      site.products.forEach((product) => {
+        productsArray.push(this.buildProductGroup(product));
+      });
+
+      if (!productsArray.length) {
+        productsArray.push(this.buildProductGroup());
+      }
+    }
+
+    this.dashboardForm.markAsPristine();
+    this.dashboardForm.markAsUntouched();
+    this.hasUnsavedChanges.set(false);
+  }
+
+  private buildProductGroup(initial?: ProductDetails): ProductFormGroup {
+    return this.fb.group({
+      name: this.fb.control(initial?.name ?? '', [Validators.required, Validators.maxLength(60)]),
+      description: this.fb.control(initial?.description ?? '', [Validators.required, Validators.maxLength(200)]),
+      price: this.fb.control(initial?.price ?? 0, [Validators.required, Validators.min(0)]),
+      imageUrl: this.fb.control(initial?.imageUrl ?? '', [Validators.required]),
+      highlight: this.fb.control(initial?.highlight ?? '', [Validators.maxLength(80)]),
+      slug: this.fb.control(initial?.slug ?? '', [Validators.maxLength(80)]),
+      gallery: this.fb.control(this.formatList(initial?.gallery), [Validators.maxLength(800)]),
+      sizes: this.fb.control(this.formatList(initial?.sizes), [Validators.maxLength(200)]),
+      colors: this.fb.control(this.formatList(initial?.colors), [Validators.maxLength(200)]),
+      category: this.fb.control(initial?.category ?? '', [Validators.maxLength(60)]),
+      subCategory: this.fb.control(initial?.subCategory ?? '', [Validators.maxLength(60)])
+    });
+  }
+
+  private parseList(value: string): string[] | undefined {
+    const entries = value
+      .split(/[\n,]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+
+    return entries.length ? entries : undefined;
+  }
+
+  private formatList(items?: string[]): string {
+    return items?.join('\n') ?? '';
+  }
+
+  private generateSlug(candidate: string, index: number, used: Set<string>): string {
+    const fallback = `product-${index + 1}`;
+    const normalized = candidate
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 80);
+
+    let slug = normalized || fallback;
+    let suffix = 1;
+
+    while (used.has(slug)) {
+      slug = `${normalized || fallback}-${suffix}`;
+      suffix += 1;
+    }
+
+    used.add(slug);
+    return slug;
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { AdminDashboardComponent } from './admin/admin-dashboard.component';
 import { LoginComponent } from './auth/login.component';
 import { SignupComponent } from './auth/signup.component';
 import { CheckoutComponent } from './cart/checkout.component';
@@ -13,5 +14,6 @@ export const routes: Routes = [
   { path: 'favorites', component: FavoritesComponent },
   { path: 'auth/login', component: LoginComponent },
   { path: 'auth/signup', component: SignupComponent },
+  { path: 'admin', component: AdminDashboardComponent },
   { path: '**', redirectTo: '' }
 ];


### PR DESCRIPTION
## Summary
- add an /admin route that loads a standalone admin dashboard component
- build a reactive management workspace to edit branding, contact details, and product catalog
- apply a refined dashboard layout with reusable button styles and status indicators

## Testing
- npm run build *(fails: Angular budget check exceeds existing checkout.component.scss budget)*

------
https://chatgpt.com/codex/tasks/task_e_68d53f36af088326a484889517865ba9