### PR TITLE
Rework admin dashboard to surface live storefront data

### DIFF
--- a/src/app/admin/admin-dashboard.component.html
+++ b/src/app/admin/admin-dashboard.component.html
@@ -1,0 +1,300 @@
+@if (isAdmin()) {
+  <div class="admin-dashboard">
+    <header class="admin-dashboard__masthead">
+      <div>
+        <p class="admin-dashboard__eyebrow">Operations overview</p>
+        <h1>Admin control center</h1>
+        <p>
+          Review storefront health, catalog performance, and customer activity without leaving the
+          dashboard.
+        </p>
+      </div>
+      <div class="admin-dashboard__actions">
+        <button type="button" class="ghost" (click)="startWizard()">Launch setup wizard</button>
+        <a class="primary" routerLink="/">View storefront</a>
+      </div>
+    </header>
+
+    <section class="admin-dashboard__metrics">
+      <article class="metric-card">
+        <span class="metric-card__label">Products live</span>
+        <span class="metric-card__value">{{ totalProducts() }}</span>
+        <small class="metric-card__meta">
+          @if (totalProducts()) {
+            {{ totalCategories() }} categories published
+          } @else {
+            No products created yet
+          }
+        </small>
+      </article>
+      <article class="metric-card">
+        <span class="metric-card__label">Customers</span>
+        <span class="metric-card__value">{{ totalCustomers() }}</span>
+        <small class="metric-card__meta">
+          @if (totalCustomers()) {
+            {{ engagedCustomers() }} with orders
+          } @else {
+            Waiting for first sign up
+          }
+        </small>
+      </article>
+      <article class="metric-card">
+        <span class="metric-card__label">Orders</span>
+        <span class="metric-card__value">{{ totalOrders() }}</span>
+        <small class="metric-card__meta">
+          @if (totalOrders()) {
+            {{ totalUnitsSold() }} items sold
+          } @else {
+            No orders captured yet
+          }
+        </small>
+      </article>
+      <article class="metric-card">
+        <span class="metric-card__label">Revenue</span>
+        <span class="metric-card__value">{{ totalRevenue() | currency }}</span>
+        <small class="metric-card__meta">
+          @if (totalOrders()) {
+            Avg. order {{ averageOrderValue() | currency }}
+          } @else {
+            Waiting for first sale
+          }
+        </small>
+      </article>
+    </section>
+
+    <section class="panel panel--store">
+      <header class="panel__header">
+        <div>
+          <h2>Storefront snapshot</h2>
+          <p>Live branding, hero, and contact details pulled from the published experience.</p>
+        </div>
+      </header>
+      @if (hasSite()) {
+        <div class="store-card" [style.--primary-color]="storePalette().primary" [style.--accent-color]="storePalette().accent">
+          <div
+            class="store-card__hero"
+            [class.store-card__hero--empty]="!heroBackground()"
+            [style.background-image]="heroBackground() ?? 'none'"
+          >
+            <div class="store-card__hero-content">
+              <span class="store-card__badge">{{ site()?.heroCtaLabel }}</span>
+              <h3>{{ site()?.storeName }}</h3>
+              <p>{{ site()?.tagline }}</p>
+              <small>Primary CTA links to {{ site()?.heroCtaLink }}</small>
+            </div>
+          </div>
+          <div class="store-card__details">
+            <dl class="store-card__list">
+              <div>
+                <dt>Logo</dt>
+                <dd>
+                  @if (site()?.logoUrl) {
+                    <a [href]="site()?.logoUrl" target="_blank" rel="noopener">{{ site()?.logoUrl }}</a>
+                  } @else {
+                    Not provided
+                  }
+                </dd>
+              </div>
+              <div>
+                <dt>About section</dt>
+                <dd>
+                  <strong>{{ site()?.about?.title }}</strong>
+                  <p>{{ site()?.about?.description }}</p>
+                </dd>
+              </div>
+              <div>
+                <dt>Contact</dt>
+                <dd>
+                  <ul class="store-card__contact">
+                    @if (site()?.contact?.contactEmail) {
+                      <li>Email: <a [href]="'mailto:' + site()?.contact?.contactEmail">{{ site()?.contact?.contactEmail }}</a></li>
+                    }
+                    @if (site()?.contact?.contactPhone) {
+                      <li>Phone: {{ site()?.contact?.contactPhone }}</li>
+                    }
+                    @if (site()?.contact?.contactAddress) {
+                      <li>Address: {{ site()?.contact?.contactAddress }}</li>
+                    }
+                    @if (site()?.contact?.instagramUrl) {
+                      <li>Instagram: <a [href]="site()?.contact?.instagramUrl" target="_blank" rel="noopener">{{ site()?.contact?.instagramUrl }}</a></li>
+                    }
+                    @if (site()?.contact?.facebookUrl) {
+                      <li>Facebook: <a [href]="site()?.contact?.facebookUrl" target="_blank" rel="noopener">{{ site()?.contact?.facebookUrl }}</a></li>
+                    }
+                  </ul>
+                  @if (!site()?.contact?.contactEmail && !site()?.contact?.contactPhone && !site()?.contact?.contactAddress && !site()?.contact?.instagramUrl && !site()?.contact?.facebookUrl) {
+                    <p class="store-card__empty">No contact details configured.</p>
+                  }
+                </dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      } @else {
+        <div class="panel__empty">
+          <h3>No storefront configured</h3>
+          <p>Launch the setup wizard to generate your first storefront experience.</p>
+        </div>
+      }
+    </section>
+
+    <div class="admin-dashboard__grid admin-dashboard__grid--two">
+      <section class="panel panel--products">
+        <header class="panel__header">
+          <div>
+            <h2>Catalog spotlight</h2>
+            <p>Showing up to eight products currently visible in the store.</p>
+          </div>
+        </header>
+        @if (totalProducts()) {
+          <div class="product-grid">
+            @for (product of productSnapshots(); track product.slug) {
+              <article class="product-tile">
+                <div class="product-tile__head">
+                  <h3>{{ product.name }}</h3>
+                  @if (product.highlight) {
+                    <span class="pill pill--accent">{{ product.highlight }}</span>
+                  }
+                </div>
+                <p class="product-tile__meta">
+                  {{ product.category ?? 'Uncategorized' }}
+                  @if (product.subCategory) {
+                    · {{ product.subCategory }}
+                  }
+                </p>
+                <p class="product-tile__price">{{ product.price | currency }}</p>
+                <p class="product-tile__slug">/{{ product.slug }}</p>
+              </article>
+            }
+          </div>
+          <footer class="panel__footer">
+            Catalog value {{ catalogValue() | currency }}
+            @if (totalProducts() > productSnapshots().length) {
+              · {{ totalProducts() - productSnapshots().length }} additional products not shown.
+            }
+          </footer>
+        } @else {
+          <div class="panel__empty">
+            <h3>No products yet</h3>
+            <p>Use the wizard to add items to your catalog.</p>
+          </div>
+        }
+      </section>
+
+      <section class="panel panel--customers">
+        <header class="panel__header">
+          <div>
+            <h2>Customer activity</h2>
+            <p>Track registered shoppers and their purchasing cadence.</p>
+          </div>
+        </header>
+        @if (totalCustomers()) {
+          <ul class="customer-list">
+            @for (customer of topCustomers(); track customer.id) {
+              <li class="customer-card">
+                <div class="customer-card__identity">
+                  <h3>{{ customer.name }}</h3>
+                  <a [href]="'mailto:' + customer.email">{{ customer.email }}</a>
+                </div>
+                <div class="customer-card__stats">
+                  <span>{{ customer.orders }} orders</span>
+                  <span>{{ customer.totalSpent | currency }}</span>
+                </div>
+                <p class="customer-card__meta">
+                  @if (customer.lastOrderAt) {
+                    Last order {{ customer.lastOrderAt | date: 'mediumDate' }}
+                  } @else {
+                    Yet to place an order
+                  }
+                </p>
+              </li>
+            }
+          </ul>
+          @if (totalCustomers() > topCustomers().length) {
+            <footer class="panel__footer">
+              {{ totalCustomers() - topCustomers().length }} more customer(s) available in the list.
+            </footer>
+          }
+        } @else {
+          <div class="panel__empty">
+            <h3>No customer sign ups</h3>
+            <p>Encourage visitors to create an account to track their orders.</p>
+          </div>
+        }
+      </section>
+    </div>
+
+    <section class="panel panel--orders">
+      <header class="panel__header">
+        <div>
+          <h2>Recent orders</h2>
+          <p>Monitor fulfillment details and payment methods for incoming orders.</p>
+        </div>
+      </header>
+      @if (totalOrders()) {
+        <ul class="order-list">
+          @for (order of recentOrders(); track order.id) {
+            <li class="order-card">
+              <div class="order-card__primary">
+                <span class="order-card__id">#{{ order.id }}</span>
+                <span class="order-card__total">{{ order.total | currency }}</span>
+              </div>
+              <div class="order-card__meta">
+                <span>{{ order.placedAt | date: 'medium' }}</span>
+                <span>{{ order.itemCount }} items · {{ order.paymentMethod | titlecase }}</span>
+              </div>
+              <div class="order-card__customer">
+                <span>{{ order.customerName }}</span>
+                <a [href]="'mailto:' + order.customerEmail">{{ order.customerEmail }}</a>
+              </div>
+              <ul class="order-card__items">
+                @for (item of order.items; track $index) {
+                  <li>
+                    <span class="order-card__item-name">{{ item.quantity }}× {{ item.name }}</span>
+                    @if (item.variant?.size || item.variant?.color) {
+                      <span class="order-card__variant">
+                        (
+                        @if (item.variant?.size) {
+                          {{ item.variant?.size }}
+                        }
+                        @if (item.variant?.size && item.variant?.color) {
+                          ·
+                        }
+                        @if (item.variant?.color) {
+                          {{ item.variant?.color }}
+                        }
+                        )
+                      </span>
+                    }
+                  </li>
+                }
+              </ul>
+            </li>
+          }
+        </ul>
+        <footer class="panel__footer">
+          Showing {{ recentOrders().length }} of {{ totalOrders() }} order(s).
+          @if (lastOrderAt()) {
+            Last order placed {{ lastOrderAt() | date: 'medium' }}
+          }
+        </footer>
+      } @else {
+        <div class="panel__empty">
+          <h3>No orders received</h3>
+          <p>Orders will appear here as soon as customers check out.</p>
+        </div>
+      }
+    </section>
+  </div>
+} @else {
+  <div class="admin-dashboard__unauthorized">
+    <div class="unauthorized-card">
+      <h1>Admin access required</h1>
+      <p>
+        This workspace is reserved for team members with administrative permissions. Sign in with an
+        authorized account to continue.
+      </p>
+      <a class="primary" routerLink="/auth/login">Go to sign in</a>
+    </div>
+  </div>
+}

--- a/src/app/admin/admin-dashboard.component.scss
+++ b/src/app/admin/admin-dashboard.component.scss
@@ -1,0 +1,582 @@
+:host {
+  display: block;
+  min-height: 100vh;
+  padding: 3rem 1.5rem 4rem;
+  background: radial-gradient(circle at top left, #eef2ff 0%, #f8fafc 55%, #ffffff 100%);
+  color: #0f172a;
+}
+
+.admin-dashboard {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.admin-dashboard__masthead {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1.5rem;
+  padding: 2.5rem;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(59, 130, 246, 0.05));
+  box-shadow:
+    0 20px 40px -24px rgba(15, 23, 42, 0.2),
+    0 12px 24px -16px rgba(15, 23, 42, 0.18);
+}
+
+.admin-dashboard__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-weight: 600;
+  font-size: 0.75rem;
+  color: #1d4ed8;
+  margin-bottom: 0.75rem;
+}
+
+.admin-dashboard__masthead h1 {
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  margin: 0 0 0.75rem;
+  color: #0f172a;
+}
+
+.admin-dashboard__masthead p {
+  max-width: 38ch;
+  font-size: 1rem;
+  color: #334155;
+  margin: 0;
+}
+
+.admin-dashboard__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+button.ghost,
+a.ghost {
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  background: rgba(255, 255, 255, 0.7);
+  color: #0f172a;
+  border-radius: 999px;
+  padding: 0.6rem 1.4rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-decoration: none;
+}
+
+button.ghost:hover,
+a.ghost:hover {
+  border-color: rgba(37, 99, 235, 0.4);
+  color: #1d4ed8;
+  background: rgba(37, 99, 235, 0.08);
+}
+
+a.primary,
+button.primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.65rem 1.6rem;
+  background: linear-gradient(135deg, #2563eb, #1e40af);
+  color: #ffffff;
+  font-weight: 600;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 12px 24px -16px rgba(37, 99, 235, 0.65);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+a.primary:hover,
+button.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 30px -18px rgba(37, 99, 235, 0.6);
+}
+
+.admin-dashboard__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.metric-card {
+  background: #ffffff;
+  border-radius: 22px;
+  padding: 1.75rem;
+  box-shadow: 0 16px 32px -26px rgba(15, 23, 42, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.metric-card__label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: #475569;
+}
+
+.metric-card__value {
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.metric-card__meta {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.panel {
+  background: #ffffff;
+  border-radius: 26px;
+  padding: 2rem;
+  box-shadow: 0 18px 36px -28px rgba(15, 23, 42, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.panel__header h2 {
+  font-size: 1.4rem;
+  margin: 0 0 0.35rem;
+  color: #0f172a;
+}
+
+.panel__header p {
+  margin: 0;
+  color: #475569;
+  max-width: 44ch;
+}
+
+.panel__footer {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.panel__empty {
+  text-align: center;
+  padding: 2.5rem 1.5rem;
+  border-radius: 20px;
+  background: rgba(241, 245, 249, 0.6);
+  color: #475569;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.panel__empty h3 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.admin-dashboard__grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.admin-dashboard__grid--two {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.store-card {
+  --primary-color: #2563eb;
+  --accent-color: #f97316;
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.store-card__hero {
+  position: relative;
+  min-height: 220px;
+  border-radius: 22px;
+  overflow: hidden;
+  background-color: #0f172a;
+  background-size: cover;
+  background-position: center;
+  color: #f8fafc;
+  display: flex;
+  align-items: flex-end;
+}
+
+.store-card__hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.68), rgba(15, 23, 42, 0.2));
+}
+
+.store-card__hero--empty {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.45), rgba(29, 78, 216, 0.45));
+}
+
+.store-card__hero-content {
+  position: relative;
+  z-index: 1;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.store-card__hero-content h3 {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 700;
+}
+
+.store-card__hero-content p {
+  margin: 0;
+  color: rgba(241, 245, 249, 0.85);
+}
+
+.store-card__hero-content small {
+  color: rgba(241, 245, 249, 0.7);
+}
+
+.store-card__badge {
+  align-self: flex-start;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.15);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.store-card__details {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.store-card__list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin: 0;
+}
+
+.store-card__list div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.store-card__list dt {
+  font-size: 0.85rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.store-card__list dd {
+  margin: 0;
+  color: #0f172a;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.store-card__list dd a {
+  color: #1d4ed8;
+  font-weight: 600;
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.store-card__list dd a:hover {
+  text-decoration: underline;
+}
+
+.store-card__contact {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.95rem;
+}
+
+.store-card__empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.product-tile {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 18px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: rgba(248, 250, 252, 0.55);
+}
+
+.product-tile__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.product-tile__head h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.product-tile__meta {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.product-tile__price {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: #1f2937;
+}
+
+.product-tile__slug {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #94a3b8;
+  text-transform: lowercase;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.8rem;
+  background: rgba(15, 23, 42, 0.08);
+  color: #0f172a;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+}
+
+.pill--accent {
+  background: var(--accent-color, rgba(249, 115, 22, 0.18));
+  color: #c2410c;
+}
+
+.customer-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.customer-card {
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  padding: 1.25rem;
+  background: rgba(248, 250, 252, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.customer-card__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.customer-card__identity h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #0f172a;
+}
+
+.customer-card__identity a {
+  font-size: 0.9rem;
+  color: #2563eb;
+  text-decoration: none;
+  word-break: break-word;
+}
+
+.customer-card__identity a:hover {
+  text-decoration: underline;
+}
+
+.customer-card__stats {
+  display: flex;
+  gap: 1.25rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.customer-card__meta {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.order-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.order-card {
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: 20px;
+  padding: 1.5rem;
+  background: rgba(248, 250, 252, 0.65);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.order-card__primary {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.order-card__id {
+  font-weight: 700;
+  font-size: 1rem;
+  color: #1f2937;
+}
+
+.order-card__total {
+  font-weight: 700;
+  font-size: 1.2rem;
+  color: #0f172a;
+}
+
+.order-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.order-card__customer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: #0f172a;
+}
+
+.order-card__customer a {
+  color: #2563eb;
+  text-decoration: none;
+}
+
+.order-card__customer a:hover {
+  text-decoration: underline;
+}
+
+.order-card__items {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.order-card__item-name {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.order-card__variant {
+  margin-left: 0.35rem;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.admin-dashboard__unauthorized {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(160deg, rgba(37, 99, 235, 0.1), rgba(236, 72, 153, 0.08));
+  padding: 3rem 1.5rem;
+}
+
+.unauthorized-card {
+  max-width: 420px;
+  background: #ffffff;
+  padding: 3rem 2.5rem;
+  border-radius: 28px;
+  box-shadow: 0 24px 48px -32px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  text-align: center;
+  color: #0f172a;
+}
+
+.unauthorized-card h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.unauthorized-card p {
+  margin: 0;
+  color: #475569;
+  line-height: 1.6;
+}
+
+.unauthorized-card .primary {
+  align-self: center;
+}
+
+@media (max-width: 768px) {
+  .admin-dashboard {
+    gap: 2rem;
+  }
+
+  .admin-dashboard__masthead {
+    padding: 2rem;
+  }
+
+  .panel {
+    padding: 1.75rem;
+  }
+}

--- a/src/app/admin/admin-dashboard.component.ts
+++ b/src/app/admin/admin-dashboard.component.ts
@@ -1,0 +1,162 @@
+import { CommonModule, CurrencyPipe, DatePipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+import { AuthService } from '../auth/auth.service';
+import { OrderRecord } from '../models/auth.model';
+import { ProductDetails } from '../models/site.model';
+import { SiteStateService } from '../state/site-state.service';
+
+type CustomerSnapshot = {
+  id: string;
+  name: string;
+  email: string;
+  orders: number;
+  totalSpent: number;
+  lastOrderAt: string | null;
+  lastOrderTimestamp: number;
+};
+
+type OrderSnapshot = OrderRecord & {
+  customerName: string;
+  customerEmail: string;
+  itemCount: number;
+};
+
+type ProductSnapshot = Pick<
+  ProductDetails,
+  'name' | 'slug' | 'price' | 'highlight' | 'category' | 'subCategory'
+>;
+
+@Component({
+  selector: 'app-admin-dashboard',
+  standalone: true,
+  imports: [CommonModule, RouterLink, DatePipe, CurrencyPipe],
+  templateUrl: './admin-dashboard.component.html',
+  styleUrls: ['./admin-dashboard.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AdminDashboardComponent {
+  private readonly siteState = inject(SiteStateService);
+  private readonly auth = inject(AuthService);
+  private readonly router = inject(Router);
+
+  protected readonly isAdmin = this.auth.isAdmin;
+  protected readonly hasSite = this.siteState.hasSite;
+  protected readonly site = this.siteState.site;
+  protected readonly products = this.siteState.products;
+  protected readonly users = this.auth.users;
+
+  protected readonly productSnapshots = computed<ProductSnapshot[]>(() =>
+    this.products()
+      .map((product) => ({
+        name: product.name,
+        slug: product.slug,
+        price: product.price,
+        highlight: product.highlight,
+        category: product.category,
+        subCategory: product.subCategory
+      }))
+      .slice(0, 8)
+  );
+
+  protected readonly totalProducts = computed(() => this.products().length);
+
+  protected readonly totalCategories = computed(() => {
+    const categories = new Set<string>();
+    this.products().forEach((product) => {
+      const category = product.category?.trim();
+      if (category) {
+        categories.add(category.toLowerCase());
+      }
+    });
+    return categories.size;
+  });
+
+  protected readonly catalogValue = computed(() =>
+    this.products().reduce((sum, product) => sum + product.price, 0)
+  );
+
+  protected readonly customerSnapshots = computed<CustomerSnapshot[]>(() =>
+    this.users()
+      .filter((user) => user.role === 'member')
+      .map((user) => {
+        const orders = [...(user.orders ?? [])];
+        const lastOrder = orders
+          .slice()
+          .sort((a, b) => new Date(b.placedAt).getTime() - new Date(a.placedAt).getTime())[0];
+        const totalSpent = orders.reduce((sum, order) => sum + order.total, 0);
+        return {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+          orders: orders.length,
+          totalSpent,
+          lastOrderAt: lastOrder?.placedAt ?? null,
+          lastOrderTimestamp: lastOrder ? new Date(lastOrder.placedAt).getTime() : 0
+        } satisfies CustomerSnapshot;
+      })
+      .sort((a, b) => {
+        if (b.lastOrderTimestamp === a.lastOrderTimestamp) {
+          return b.orders - a.orders;
+        }
+        return b.lastOrderTimestamp - a.lastOrderTimestamp;
+      })
+  );
+
+  protected readonly topCustomers = computed(() => this.customerSnapshots().slice(0, 6));
+  protected readonly totalCustomers = computed(() => this.customerSnapshots().length);
+  protected readonly engagedCustomers = computed(
+    () => this.customerSnapshots().filter((customer) => customer.orders > 0).length
+  );
+
+  protected readonly orderSnapshots = computed<OrderSnapshot[]>(() => {
+    const allOrders = this.users().flatMap((user) =>
+      (user.orders ?? []).map<OrderSnapshot>((order) => ({
+        ...order,
+        customerName: user.name,
+        customerEmail: user.email,
+        itemCount: order.items.reduce((count, item) => count + item.quantity, 0)
+      }))
+    );
+
+    return allOrders
+      .slice()
+      .sort((a, b) => new Date(b.placedAt).getTime() - new Date(a.placedAt).getTime());
+  });
+
+  protected readonly recentOrders = computed(() => this.orderSnapshots().slice(0, 6));
+  protected readonly totalOrders = computed(() => this.orderSnapshots().length);
+  protected readonly totalUnitsSold = computed(() =>
+    this.orderSnapshots().reduce((sum, order) => sum + order.itemCount, 0)
+  );
+  protected readonly totalRevenue = computed(() =>
+    this.orderSnapshots().reduce((sum, order) => sum + order.total, 0)
+  );
+  protected readonly averageOrderValue = computed(() => {
+    const count = this.totalOrders();
+    return count ? this.totalRevenue() / count : 0;
+  });
+  protected readonly lastOrderAt = computed(() => this.orderSnapshots()[0]?.placedAt ?? null);
+
+  protected readonly heroBackground = computed(() => {
+    const heroImage = this.site()?.heroImageUrl;
+    if (!heroImage) {
+      return null;
+    }
+    return `linear-gradient(180deg, rgba(15, 23, 42, 0.78), rgba(15, 23, 42, 0.35)), url("${heroImage}")`;
+  });
+
+  protected readonly storePalette = computed(() => {
+    const site = this.site();
+    return {
+      primary: site?.primaryColor ?? '#2563eb',
+      accent: site?.accentColor ?? '#f97316'
+    };
+  });
+
+  protected startWizard(): void {
+    if (this.siteState.openWizard()) {
+      void this.router.navigateByUrl('/');
+    }
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { AdminDashboardComponent } from './admin/admin-dashboard.component';
 import { LoginComponent } from './auth/login.component';
 import { SignupComponent } from './auth/signup.component';
 import { CheckoutComponent } from './cart/checkout.component';
@@ -13,5 +14,6 @@ export const routes: Routes = [
   { path: 'favorites', component: FavoritesComponent },
   { path: 'auth/login', component: LoginComponent },
   { path: 'auth/signup', component: SignupComponent },
+  { path: 'admin', component: AdminDashboardComponent },
   { path: '**', redirectTo: '' }
 ];


### PR DESCRIPTION
## Summary
- rebuild the admin dashboard to surface storefront metrics, catalog entries, customers, and orders without re-running the wizard
- add data-driven panels for store branding, catalog snapshots, customer activity, and recent order details pulled from existing state
- refresh dashboard styling with metric cards, responsive panels, and contact previews tied to the live site configuration

## Testing
- npm run build *(fails: existing Angular CSS budget overage in cart/checkout.component.scss and other stylesheets)*

------
https://chatgpt.com/codex/tasks/task_e_68d53f36af088326a484889517865ba9